### PR TITLE
require locales only if not already loaded

### DIFF
--- a/date-and-time.js
+++ b/date-and-time.js
@@ -286,7 +286,7 @@
      */
     date.locale = function (code) {
         if (code) {
-            if (code !== 'en' && typeof require === 'function' && global) {
+            if (!locales[code] && typeof require === 'function' && global) {
                 require('./locale/' + code);
             }
             lang = code;


### PR DESCRIPTION
Not only removes this unnecessary calls to require, but it also enables browserifying the locales, since the dynamic require call won't allow that.