### PR TITLE
Fixed example for Invalid Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ If the function fails to parse, it will return `Invalid Date`. Notice that the `
 ```javascript
 const today = date.parse('Jam 1 2017', 'MMM D YYYY');
 
-if (isNaN(today)) {
+if (isNaN(today.getTime())) {
     // Failure
 }
 ```


### PR DESCRIPTION
The published example works in JavaScript, but won't compile with TypeScript without casting to `any`.  This code is more obvious because it does not rely on the reader knowing the special behaviour if isNan() with respect to Date objects.