### PR TITLE
fix: types exports in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # date-and-time
 
-[![Circle CI](https://circleci.com/gh/knowledgecode/date-and-time.svg?style=shield)](https://circleci.com/gh/knowledgecode/date-and-time)  
+[![Circle CI](https://circleci.com/gh/knowledgecode/date-and-time.svg?style=shield)](https://circleci.com/gh/knowledgecode/date-and-time)
 
 This JS library is just a collection of functions for manipulating date and time. It's small, simple, and easy to learn.
 
@@ -24,6 +24,9 @@ npm i date-and-time
 ```
 
 ## Recent Changes
+
+- 3.0.3
+  - Fixed TypeScript types exports in `package.json`.
 
 - 3.0.2
   - Dropped the use of the logical OR assignment operator to support older environments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "date-and-time",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "date-and-time",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-and-time",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A Minimalist DateTime utility for Node.js and the browser",
   "main": "date-and-time.js",
   "module": "esm/date-and-time.es.js",
@@ -8,16 +8,19 @@
   "unpkg": "date-and-time.min.js",
   "exports": {
     ".": {
+      "types": "./date-and-time.d.ts",
       "import": "./esm/date-and-time.mjs",
       "require": "./date-and-time.js",
       "browser": "./esm/date-and-time.es.js"
     },
     "./locale/*": {
+      "types": "./locale/*.d.ts",
       "import": "./esm/locale/*.mjs",
       "require": "./locale/*.js",
       "browser": "./esm/locale/*.es.js"
     },
     "./plugin/*": {
+      "types": "./plugin/*.d.ts",
       "import": "./esm/plugin/*.mjs",
       "require": "./plugin/*.js",
       "browser": "./esm/plugin/*.es.js"


### PR DESCRIPTION
Hey! :wave:

Thank you for making this awesome library to easily display date in the wanted format!

Found an issue: TypeScript complain with the following error:
```sh
Could not find a declaration file for module 'date-and-time'.

There are types at 'node_modules/date-and-time/date-and-time.d.ts', but this result could not be resolved when respecting package.json "exports". The 'date-and-time' library may need to update its package.json or typings.
```

To fix this, we need to define `types` property in `exports` in `package.json`.