### PR TITLE
test: remove coverage thresholds so coverage stays informational

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,13 +12,7 @@ export default defineConfig({
       exclude: ['src/**/*.d.ts'],
       include: ['src/**/*.ts'],
       provider: 'v8',
-      reporter: ['html', 'lcov'],
-      thresholds: {
-        lines: 100,
-        statements: 100,
-        functions: 100,
-        branches: 95
-      }
+      reporter: ['html', 'lcov']
     },
     include: ['tests/**/*.spec.ts']
   }


### PR DESCRIPTION
## Summary
- **test**: drop `coverage.thresholds` from `vitest.config.ts` (previously 100% lines/statements/functions, 95% branches).

Coverage is still collected and uploaded to Codecov by the `coverage` job; it's just informational now.

## Test plan
- [x] `npm run test:coverage` completes successfully (exit 0) regardless of coverage percentage
- [x] `npm run lint`
- [x] `npm run ts`